### PR TITLE
Stefan/removed always on warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,13 @@ python ConsecutiveUnsampledACTs.py
 Table V in the workshop paper shows that a sampling rate of 1 in 256 has a Rowhammer failure of 7e-6 for a threshold of 8192. To see this result, run:
 
 ```sh
-python RHSampling.py --th 8192 --prob 0.00390625 --cfg A 
+python RHSampling.py --th 8192 --rate 0.00390625 --cfg A 
 ```
 
 The scripts directory has a couple of scripts to produce the numbers presented in our paper.
 
 ## On Precision
 
-The code does a lot of floating point operations and it shows a warning whenever rounding occurs. Guess what? Rounding always occurs and thus there is always a degree of loss of precision. To gain confidence into the results, run the script several times with increased level of precisions. If the result does not change as precision increases, that's a good sign.
+ Given the nature of the computations above, the results are always inexact and rounded. However, the code uses the decimal module that supports arbitrary levels of precision. You can always increase the precision of the computation (the default is '100') and check whether the result changes (see the ``--prec`` flag).
 
-For some of the values in the paper, we had to increase the precision value to 400. (see the ``--prec`` flag).
+ In my experience with different parameters and configurations, the script can sometimes return a failure rate of '0E+00' or '1E+00'. This is an indication of an inadequate level of precision (the rowhammer failure rate can never 0% or 100%). In these cases, increase the precision and re-run the script until the failure rate changes either to a value very close to 0 or very close to 1.  

--- a/RHSampling.py
+++ b/RHSampling.py
@@ -110,11 +110,14 @@ if __name__ == '__main__':
     print('Probability of victim row escaping refresh : {}'.format(format_e(prob_no_refresh)))
     print('Probability of RH failure in a system with {} banks: {}'.format(banks, format_e(prob_rh_fail)))
 
-    # Check if Inexact or Rounded flags were set. If so, report to the user
-    if context.flags[Inexact]:
-        print(colored(255,204, 0, 'Inexact answer: non-zero digits were discarded during rounding.'))
-    elif context.flags[Rounded]:
-        print(colored(255, 204, 0, 'Rounded answer: digits (possibly zeros) were discarded during rounding.'))
-    if context.flags[Inexact] or context.flags[Rounded]:
-        print(colored(255, 204, 0, 'Try re-running the script with increased precision and see if the answer changes.'))
+    # Given the nature of the computations above, the results are always inexact and rounded. 
+    # Showing a warning for an event that always occurs is a little silly.
+    # Comment out these warnings 
+    # # Check if Inexact or Rounded flags were set. If so, report to the user
+    # if context.flags[Inexact]:
+    #     print(colored(255,204, 0, 'Inexact answer: non-zero digits were discarded during rounding.'))
+    # elif context.flags[Rounded]:
+    #     print(colored(255, 204, 0, 'Rounded answer: digits (possibly zeros) were discarded during rounding.'))
+    # if context.flags[Inexact] or context.flags[Rounded]:
+    #     print(colored(255, 204, 0, 'Try re-running the script with increased precision and see if the answer changes.'))
 

--- a/RHSampling.py
+++ b/RHSampling.py
@@ -97,17 +97,15 @@ if __name__ == '__main__':
 
     # 2/ Using the unsampled ACTs algorithm
     prob_no_sampling = pUnsampledConsecutiveACTs(W, th, p, MEMORY_OPTIMIZED)
+    # print('Probability of consecutive ACTs escaping sampling : {}'.format(format_e(prob_no_sampling)))
 
     # Compute the probability of a victim row escaping refreshing
     prob_no_refresh = PUnrefreshedRow(th, ddr.tRC, ddr.tRFW)
+    # print('Probability of victim row escaping refresh : {}'.format(format_e(prob_no_refresh)))
 
     # Compute probability of RH failure all banks in a system
     banks = Banks(host, dram)
     prob_rh_fail = Decimal('1.0') - (Decimal('1.0') - prob_no_sampling * prob_no_refresh) ** banks
-    
-    # Print result
-    print('Probability of consecutive ACTs escaping sampling : {}'.format(format_e(prob_no_sampling)))
-    print('Probability of victim row escaping refresh : {}'.format(format_e(prob_no_refresh)))
     print('Probability of RH failure in a system with {} banks: {}'.format(banks, format_e(prob_rh_fail)))
 
     # Given the nature of the computations above, the results are always inexact and rounded. 

--- a/RHSampling.py
+++ b/RHSampling.py
@@ -80,7 +80,7 @@ if __name__ == '__main__':
     W *= lt                                                 # W in lifetime
 
     print('Total # of banks: {}'.format(Banks(host, dram)))
-    print('Total # of ACTs in system\'s lifetime (in billions): {}'.format(W / 1000 / 1000 / 1000))
+    print('Approx # of ACTs in attack\'s lifetime (in billions): ~{:.2f}'.format(W / 1000 / 1000 / 1000))
 
     # Setup the context for the decimal operations. 
     # We do set traps on Inexact and Rounding, but flags only. A flag does not throw an exception, whereas trap does.
@@ -106,7 +106,7 @@ if __name__ == '__main__':
     # Compute probability of RH failure all banks in a system
     banks = Banks(host, dram)
     prob_rh_fail = Decimal('1.0') - (Decimal('1.0') - prob_no_sampling * prob_no_refresh) ** banks
-    print('Probability of RH failure in a system with {} banks: {}'.format(banks, format_e(prob_rh_fail)))
+    print('\nProbability of RH failure in a system with {} banks: {}'.format(banks, format_e(prob_rh_fail)))
 
     # Given the nature of the computations above, the results are always inexact and rounded. 
     # Showing a warning for an event that always occurs is a little silly.


### PR DESCRIPTION
Commented out showing the warnings.

Given the nature of these computations, the results are always inexact and rounded. It was little silly to show these warnings that always happen. 